### PR TITLE
Fixed Try to allow for copying around

### DIFF
--- a/algorithm/source/ddash/algorithm/flatten.d
+++ b/algorithm/source/ddash/algorithm/flatten.d
@@ -33,7 +33,7 @@ import ddash.common;
     Since:
         0.0.1
 */
-auto flatten(Range)(Range range) if (from!"std.range".isInputRange!Range) {
+auto flatten(Range)(auto ref Range range) if (from!"std.range".isInputRange!Range) {
     import std.range: ElementType, isInputRange;
     static if (isInputRange!(ElementType!Range)) {
         import std.algorithm: joiner;

--- a/algorithm/source/ddash/algorithm/package.d
+++ b/algorithm/source/ddash/algorithm/package.d
@@ -217,4 +217,8 @@ public {
     import ddash.algorithm.sort;
     import ddash.algorithm.stringify;
     import ddash.algorithm.zip;
+
+    // For convenience, import algorithms from phobos
+    static import std.algorithm;
+    alias map = std.algorithm.map;
 }

--- a/common/dub.json
+++ b/common/dub.json
@@ -3,7 +3,7 @@
     "targetType": "library",
     "targetPath": "../bin",
     "dependencies": {
-        "optional": "~>0.10.0",
+        "optional": "~>0.11.0",
         "sumtype": "~>0.8.0"
     }
 }

--- a/ddash/package.d
+++ b/ddash/package.d
@@ -1,0 +1,9 @@
+module ddash;
+
+public {
+    import ddash.algorithm;
+    import ddash.functional;
+    import ddash.lang;
+    import ddash.range;
+    import ddash.utils;
+}

--- a/utils/source/ddash/utils/expect.d
+++ b/utils/source/ddash/utils/expect.d
@@ -78,10 +78,8 @@ struct Expect(T, E = Variant) if (!is(E == void)) {
         Constructor takes a Expected and creates a success result. Or takes an E and
         creates an unexpected result
     */
-    static if (!isVoid!Expected) {
-        this(Expected value) {
-            data = value;
-        }
+    this(Expected value) {
+        data = value;
     }
 
     /// Ditto

--- a/utils/source/ddash/utils/expect.d
+++ b/utils/source/ddash/utils/expect.d
@@ -89,7 +89,11 @@ struct Expect(T, E = Variant) if (!is(E == void)) {
 
     /// Create an `Expect` with an expected value
     static expected(V : Expected)(auto ref V value) {
-        return Expect!(Expected, E)(value);
+        static if (is(T == void)) {
+            return Expect!(void, E)(value);
+        } else {
+            return Expect!(V, E)(value);
+        }
     }
 
     /// Create an `Expect` with an unexpected value


### PR DESCRIPTION
Try used to call the lambda multiple times if there were copies
of it going around. We instead store a reference to the result
of a Try expression so that passed around Try ranges call the
lambda once.